### PR TITLE
Simulate real data partitions

### DIFF
--- a/src/data.py
+++ b/src/data.py
@@ -4,11 +4,15 @@ Handling vertically partitioned data
 from copy import deepcopy
 from typing import Tuple, TypeVar
 
+import numpy as np
+
 
 Dataset = TypeVar("Dataset")
 
 
-def partition_dataset(dataset: Dataset) -> Tuple[Dataset, Dataset]:
+def partition_dataset(
+    dataset: Dataset, keep_order: bool = False
+) -> Tuple[Dataset, Dataset]:
     """
     Vertically partition a torch dataset in two
 
@@ -21,6 +25,8 @@ def partition_dataset(dataset: Dataset) -> Tuple[Dataset, Dataset]:
     ----------
     dataset : torch.utils.data.Dataset
         The dataset to split. Must be a dataset of images
+    keep_order : bool (default = False)
+        If False, shuffle the elements of each dataset
 
     Returns
     -------
@@ -46,5 +52,20 @@ def partition_dataset(dataset: Dataset) -> Tuple[Dataset, Dataset]:
 
     partition1.data = partition1.data[:, :half_height]
     partition2.data = partition2.data[:, half_height:]
+
+    if not keep_order:
+        # Shuffle dataset 1
+        idxs1 = np.arange(len(partition1))
+        np.random.shuffle(idxs1)
+
+        partition1.data = partition1.data[idxs1]
+        partition1.targets = partition1.targets[idxs1]
+
+        # Shuffle dataset 2
+        idxs2 = np.arange(len(partition2))
+        np.random.shuffle(idxs2)
+
+        partition2.data = partition2.data[idxs2]
+        partition2.targets = partition2.targets[idxs2]
 
     return partition1, partition2

--- a/src/data.py
+++ b/src/data.py
@@ -45,17 +45,26 @@ def partition_dataset(
     partition1 = deepcopy(dataset)
     partition2 = deepcopy(dataset)
 
+    # Re-index data
+    idxs1 = np.arange(len(partition1))
+    idxs2 = np.arange(len(partition2))
+
     # Remove random subsets of data with 1% prob
     if remove_data:
-        remove_idxs1 = np.random.uniform(0, 1, len(partition1)) > 0.01
-        partition1.data = partition1.data[remove_idxs1]
-        partition1.targets = partition1.targets[remove_idxs1]
+        idxs1 = np.random.uniform(0, 1, len(partition1)) > 0.01
+        idxs2 = np.random.uniform(0, 1, len(partition2)) > 0.01
 
-        # Different subsets for each dataset partition
-        remove_idxs2 = np.random.uniform(0, 1, len(partition2)) > 0.01
-        partition2.data = partition2.data[remove_idxs2]
-        partition2.targets = partition2.targets[remove_idxs2]
+    if not keep_order:
+        np.random.shuffle(idxs1)
+        np.random.shuffle(idxs2)
 
+    partition1.data = partition1.data[idxs1]
+    partition1.targets = partition1.targets[idxs1]
+
+    partition2.data = partition2.data[idxs2]
+    partition2.targets = partition2.targets[idxs2]
+
+    # Partition data
     data_shape = partition1.data.size()
 
     # Assume we're working with images at the moment
@@ -65,20 +74,5 @@ def partition_dataset(
 
     partition1.data = partition1.data[:, :half_height]
     partition2.data = partition2.data[:, half_height:]
-
-    if not keep_order:
-        # Shuffle dataset 1
-        idxs1 = np.arange(len(partition1))
-        np.random.shuffle(idxs1)
-
-        partition1.data = partition1.data[idxs1]
-        partition1.targets = partition1.targets[idxs1]
-
-        # Shuffle dataset 2
-        idxs2 = np.arange(len(partition2))
-        np.random.shuffle(idxs2)
-
-        partition2.data = partition2.data[idxs2]
-        partition2.targets = partition2.targets[idxs2]
 
     return partition1, partition2

--- a/src/data.py
+++ b/src/data.py
@@ -11,7 +11,7 @@ Dataset = TypeVar("Dataset")
 
 
 def partition_dataset(
-    dataset: Dataset, keep_order: bool = False
+    dataset: Dataset, keep_order: bool = False, remove_data: bool = True,
 ) -> Tuple[Dataset, Dataset]:
     """
     Vertically partition a torch dataset in two
@@ -27,6 +27,8 @@ def partition_dataset(
         The dataset to split. Must be a dataset of images
     keep_order : bool (default = False)
         If False, shuffle the elements of each dataset
+    remove_data : bool (default = True)
+        If True, remove datapoints with probability 0.01
 
     Returns
     -------
@@ -42,6 +44,17 @@ def partition_dataset(
     """
     partition1 = deepcopy(dataset)
     partition2 = deepcopy(dataset)
+
+    # Remove random subsets of data with 1% prob
+    if remove_data:
+        remove_idxs1 = np.random.uniform(0, 1, len(partition1)) > 0.01
+        partition1.data = partition1.data[remove_idxs1]
+        partition1.targets = partition1.targets[remove_idxs1]
+
+        # Different subsets for each dataset partition
+        remove_idxs2 = np.random.uniform(0, 1, len(partition2)) > 0.01
+        partition2.data = partition2.data[remove_idxs2]
+        partition2.targets = partition2.targets[remove_idxs2]
 
     data_shape = partition1.data.size()
 

--- a/src/data.py
+++ b/src/data.py
@@ -13,34 +13,25 @@ Dataset = TypeVar("Dataset")
 def partition_dataset(
     dataset: Dataset, keep_order: bool = False, remove_data: bool = True,
 ) -> Tuple[Dataset, Dataset]:
-    """
-    Vertically partition a torch dataset in two
+    """Vertically partition a torch dataset in two
 
     A vertical partition is when parameters for a single data point is
     split across multiple data holders.
     This function assumes the dataset to split contains images (e.g. MNIST).
     The two parts of the split dataset are the top half and bottom half of an image.
 
-    Parameters
-    ----------
-    dataset : torch.utils.data.Dataset
-        The dataset to split. Must be a dataset of images
-    keep_order : bool (default = False)
-        If False, shuffle the elements of each dataset
-    remove_data : bool (default = True)
-        If True, remove datapoints with probability 0.01
+    Args:
+        dataset (torch.utils.data.Dataset) : The dataset to split. Must be a dataset of images
+        keep_order (bool, default = False) : If False, shuffle the elements of each dataset
+        remove_data (bool, default = True) : If True, remove datapoints with probability 0.01
 
-    Returns
-    -------
-    torch.utils.data.Dataset
-        Dataset containing the first partition: the top half of the images
-    torch.utils.data.Dataset
-        Dataset containing the second partition: the bottom half of the images
+    Returns:
+        torch.utils.data.Dataset : Dataset containing the first partition: the top half of the images
+        torch.utils.data.Dataset : Dataset containing the second partition: the bottom half of the images
 
-    Raises
-    ------
-    AssertionError
-        If the size of the provided dataset does not have three elements (i.e. is not an image dataset)
+    Raises:
+        AssertionError : If the size of the provided dataset
+            does not have three elements (i.e. is not an image dataset)
     """
     partition1 = deepcopy(dataset)
     partition2 = deepcopy(dataset)

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,10 +1,13 @@
 """
 Test code in src/data.py
 """
+from copy import deepcopy
+from itertools import chain
 from shutil import rmtree
 
 import numpy as np
 import torch
+import torchvision.transforms as transforms
 from torchvision.datasets import MNIST
 
 from src.data import partition_dataset
@@ -13,14 +16,14 @@ from src.data import partition_dataset
 class TestPartition:
     @classmethod
     def setup_class(cls):
-        cls.dataset = MNIST(".", download=True)
+        cls.dataset = MNIST(".", download=True, transform=transforms.ToTensor())
 
     @classmethod
     def teardown_class(cls):
         rmtree("MNIST")
 
     def test_partition_dataset_returns_disjoint_parts_of_data(self):
-        dataset1, dataset2 = partition_dataset(self.dataset)
+        dataset1, dataset2 = partition_dataset(self.dataset, keep_order=True)
 
         # Test that we've not lost any data
         assert (
@@ -39,3 +42,57 @@ class TestPartition:
         np.testing.assert_array_equal(
             combined_data, self.dataset.data[:1_000].detach().numpy()
         )
+
+    def test_partition_jumbles_data(self):
+        dataset1, dataset2 = partition_dataset(
+            self.dataset
+        )  # keep_order = False by default
+
+        # Test that we've not lost any data
+        assert (
+            dataset1.data.detach().numpy().size + dataset2.data.detach().numpy().size
+            == self.dataset.data.detach().numpy().size
+        )
+
+        # Recombine partitioned data
+        combined_data = (
+            torch.cat((dataset1.data[:1_000], dataset2.data[:1_000]), 1)
+            .detach()
+            .numpy()
+        )
+
+        # Test that dataset1 + dataset2 recreates entire images
+        # Although the jumble may results in equal arrays (i.e. randomly jumble to the same state)
+        # this is very unlikely to happen for 1000 datapoints
+        assert (combined_data != self.dataset.data[:1_000].detach().numpy()).any()
+
+    def test_that_data_is_shuffled_with_labels(self):
+        # Create small dataset
+        dataset = deepcopy(self.dataset)
+
+        # Limit size of dataset to search
+        dataset.data = dataset.data[:3]
+        dataset.targets = dataset.targets[:3]
+
+        half_data_size = int(dataset.data.shape[1] / 2)
+
+        dataset1, dataset2 = partition_dataset(dataset)
+
+        for i in range(3):
+            datum1, label1 = dataset1[i]
+            datum1_original_idx = np.argmax(dataset.targets == label1)
+            datum1_original, _ = dataset[datum1_original_idx]
+
+            np.testing.assert_array_equal(
+                datum1.detach().numpy(),
+                datum1_original.detach().numpy()[:, :half_data_size],
+            )
+
+            datum2, label2 = dataset2[i]
+            datum2_original_idx = np.argmax(dataset.targets == label2)
+            datum2_original, _ = dataset[datum2_original_idx]
+
+            np.testing.assert_array_equal(
+                datum2.detach().numpy(),
+                datum2_original.detach().numpy()[:, half_data_size:],
+            )


### PR DESCRIPTION
## Description
This PR adds functionality to (i) randomly shuffle data in each partition and (ii) randomly remove pieces of data from each partition, independently. With this PR, the `partition_dataset` function produces data which better resembles real data. Disordered data necessitates a privacy-preserving mechanism to re-combine it, such as PSI.

Fixes #7 
Fixes #9 

## How has this been tested?
- Unit tests have been added to test functionality

## Checklist
- [X] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [X] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [X] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [X] My changes are covered by tests
