### PR TITLE
change partitioning to (images, labels)

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ To create a vertically partitioned dataset:
 from torchvision.datasets import MNIST
 from torchvision.transforms import ToTensor
 
-from src.dataloader import VerticalDataLoader
+from src.dataloader import PartitionDistributingDataLoader
 from src.dataset import add_ids, partition_dataset
 
 # Create dataset
@@ -69,9 +69,9 @@ data = add_ids(MNIST)(".", download=True, transform=ToTensor())  # add_ids adds 
 data_partition1, data_partition2 = partition_dataset(data)
 
 # Batch data
-dataloader = VerticalDataLoader(data_partition1, batch_size=128)
+dataloader = PartitionDistributingDataLoader(data_partition1, data_partition2, batch_size=128)
 
-for data, targets, ids in dataloader:
+for (data, ids1), (labels, ids2) in dataloader:
     # Train a model
     pass
 ```

--- a/src/dataloader.py
+++ b/src/dataloader.py
@@ -35,7 +35,27 @@ def id_collate_fn(batch: Tuple) -> List:
 
 
 class VerticalDataLoader(DataLoader):
+    """DataLoader for a single vertically-partitioned dataset
+    """
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
         self.collate_fn = id_collate_fn
+
+
+class PartitionDistributingDataLoader:
+    """Dataloader which batches data from a complete
+    set of vertically-partitioned datasets
+    i.e. the images dataset AND the labels dataset
+    """
+
+    def __init__(self, dataset1, dataset2, *args, **kwargs):
+        assert dataset1.targets is None
+        assert dataset2.data is None
+
+        self.dataloader1 = VerticalDataLoader(dataset1, *args, **kwargs)
+        self.dataloader2 = VerticalDataLoader(dataset2, *args, **kwargs)
+
+    def __iter__(self):
+        return zip(self.dataloader1, self.dataloader2)

--- a/tests/test_dataloader.py
+++ b/tests/test_dataloader.py
@@ -1,0 +1,92 @@
+"""
+Test code in src/dataloader.py
+"""
+from shutil import rmtree
+
+import pytest
+import torchvision.transforms as transforms
+from torchvision.datasets import MNIST
+
+from src.dataloader import VerticalDataLoader, PartitionDistributingDataLoader
+from src.dataset import add_ids, partition_dataset
+
+
+class TestVerticalDataLoader:
+    @classmethod
+    def setup_class(cls):
+        dataset = add_ids(MNIST)(
+            "./TestVerticalDataset", download=True, transform=transforms.ToTensor(),
+        )
+
+        dataset1, dataset2 = partition_dataset(dataset)
+        cls.dataset1 = dataset1
+        cls.dataset2 = dataset2
+
+    @classmethod
+    def teardown_class(cls):
+        rmtree("./TestVerticalDataset")
+
+    def test_that_vertical_dataloader_only_returns_data_which_is_not_none(self):
+        dataloader1 = VerticalDataLoader(self.dataset1, batch_size=100)
+        for results in dataloader1:
+            assert len(results) == 2
+
+            # IDs should have been converted to string
+            assert isinstance(results[1][0], str)
+
+        dataloader2 = VerticalDataLoader(self.dataset2, batch_size=100)
+        for results in dataloader2:
+            assert len(results) == 2
+
+            # IDs should have been converted to string
+            assert isinstance(results[1][0], str)
+
+
+class TestPartitionDistributingDataLoader:
+    @classmethod
+    def setup_class(cls):
+        dataset = add_ids(MNIST)(
+            "./TestPartitionDistributingDataLoader",
+            download=True,
+            transform=transforms.ToTensor(),
+        )
+
+        dataset1, dataset2 = partition_dataset(
+            dataset, remove_data=False,
+        )  # for now, until PSI allows us to re-balance datasets
+        cls.dataset1 = dataset1
+        cls.dataset2 = dataset2
+
+    @classmethod
+    def teardown_class(cls):
+        rmtree("./TestPartitionDistributingDataLoader")
+
+    def test_vertical_dataloader_batches_partitioned_datasets(self):
+        dataloader = PartitionDistributingDataLoader(
+            self.dataset1, self.dataset2, batch_size=100
+        )
+
+        for results in dataloader:
+            assert len(results) == 2  # dataset1_data, dataset2_data
+
+            assert len(results[0]) == 2  # images, ids1
+            assert len(results[1]) == 2  # labels, ids1
+
+            # Both IDs should be length 100
+            assert len(results[0][1]) == len(results[1][1]) == 100
+
+            # ID objects should be converted to str
+            assert isinstance(results[0][1][0], str)
+            assert isinstance(results[1][1][0], str)
+
+    def test_that_dataset1_must_not_have_targets(self):
+        with pytest.raises(AssertionError):
+            dataloader = PartitionDistributingDataLoader(
+                self.dataset2, self.dataset2, batch_size=100
+            )
+
+    def test_that_dataset2_must_not_have_data(self):
+        with pytest.raises(AssertionError):
+            dataloader = PartitionDistributingDataLoader(
+                self.dataset1, self.dataset1, batch_size=100
+            )

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1,5 +1,5 @@
 """
-Test code in src/data.py
+Test code in src/dataset.py
 """
 from copy import deepcopy
 from shutil import rmtree
@@ -10,43 +10,7 @@ import torch
 import torchvision.transforms as transforms
 from torchvision.datasets import MNIST
 
-from src.dataloader import VerticalDataLoader
 from src.dataset import add_ids, partition_dataset
-
-
-class xTestVerticalDataset:
-    @classmethod
-    def setup_class(cls):
-        cls.dataset = add_ids(MNIST)(
-            "./TestVerticalDataset", download=True, transform=transforms.ToTensor()
-        )
-
-    @classmethod
-    def teardown_class(cls):
-        rmtree("./TestVerticalDataset")
-
-    def test_that_ids_are_unique(self):
-        assert np.unique(self.dataset.ids).size == len(self.dataset)
-
-    def test_that_getitem_returns_id(self):
-        results = self.dataset[5]
-
-        assert len(results) == 3
-        assert isinstance(results[0], torch.Tensor)  # transform should be retained
-
-        assert isinstance(results[2], uuid.UUID)
-
-    def test_vertical_dataset_can_be_used_in_dataloader(self):
-        dataloader = VerticalDataLoader(self.dataset, batch_size=100)
-
-        for results in dataloader:
-            assert len(results) == 3
-            assert len(results[2]) == 100
-
-            # ID objects should be converted to str
-            assert isinstance(results[2][0], str)
-
-            break
 
 
 class TestPartition:

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -14,7 +14,7 @@ from src.dataloader import VerticalDataLoader
 from src.dataset import add_ids, partition_dataset
 
 
-class TestVerticalDataset:
+class xTestVerticalDataset:
     @classmethod
     def setup_class(cls):
         cls.dataset = add_ids(MNIST)(
@@ -65,46 +65,53 @@ class TestPartition:
             self.dataset, keep_order=True, remove_data=False
         )
 
-        # Test that we've not lost any data
+        # ----- Test that we've not lost any data -----
+        # Dataset1 has images
         assert (
-            dataset1.data.detach().numpy().size + dataset2.data.detach().numpy().size
+            dataset1.data.detach().numpy().size
             == self.dataset.data.detach().numpy().size
         )
 
-        # Recombine partitioned data
-        combined_data = (
-            torch.cat((dataset1.data[:1_000], dataset2.data[:1_000]), 1)
-            .detach()
-            .numpy()
-        )
+        # Dataset2 has labels
+        # check that dataset.__len__ for label dataset still works
+        assert len(dataset2) == len(self.dataset.targets)
 
-        # Test that dataset1 + dataset2 recreates entire images
-        np.testing.assert_array_equal(
-            combined_data, self.dataset.data[:1_000].detach().numpy()
-        )
+        # ----- Test that datsets only hold either images or labels -----
+        assert dataset1.targets is None
+        assert dataset2.data is None
 
-    def test_partition_jumbles_data(self):
+        # ----- Test that calling a dataset returns existing data + ID only -----
+        data, id1 = dataset1[0]
+        assert isinstance(data, torch.Tensor)
+        assert isinstance(id1, uuid.UUID)
+
+        label, id2 = dataset2[0]
+        assert isinstance(label, int)
+        assert isinstance(id2, uuid.UUID)
+
+    def test_partition_shuffles_data(self):
+        # Shuffle data, but don't remove any
         dataset1, dataset2 = partition_dataset(
             self.dataset, remove_data=False,
         )  # keep_order = False by default
 
-        # Test that we've not lost any data
+        # ----- Test that we've not lost any data -----
+        # Dataset1 has images
         assert (
-            dataset1.data.detach().numpy().size + dataset2.data.detach().numpy().size
+            dataset1.data.detach().numpy().size
             == self.dataset.data.detach().numpy().size
         )
 
-        # Recombine partitioned data
-        combined_data = (
-            torch.cat((dataset1.data[:1_000], dataset2.data[:1_000]), 1)
-            .detach()
-            .numpy()
-        )
+        # Dataset2 has labels
+        assert len(dataset2.targets) == len(self.dataset.targets)
 
-        # Test that dataset1 + dataset2 recreates entire images
-        # Although the jumble may results in equal arrays (i.e. randomly jumble to the same state)
+        # ----- Test that dataset1 + dataset2 recreates entire images -----
+        # Although the shuffle may results in equal arrays (i.e. randomly shuffle to the same state)
         # this is very unlikely to happen for 1000 datapoints
-        assert (combined_data != self.dataset.data[:1_000].detach().numpy()).any()
+        assert (
+            dataset2.targets.detach().numpy()[:1_000]
+            != self.dataset.targets.detach().numpy()[:1_000]
+        ).any()
 
     def test_that_data_is_shuffled_with_labels(self):
         # Create small dataset
@@ -119,25 +126,19 @@ class TestPartition:
         dataset1, dataset2 = partition_dataset(dataset, remove_data=False)
 
         for i in range(3):
-            datum1, label1, id1 = dataset1[i]
-            datum1_original_idx = np.argmax(dataset.targets == label1)
+            datum1, id1 = dataset1[i]
+            datum1_original_idx = np.argmax(dataset.ids == id1)
             datum1_original, _, id1_original = dataset[datum1_original_idx]
 
             np.testing.assert_array_equal(
-                datum1.detach().numpy(),
-                datum1_original.detach().numpy()[:, :half_data_size],
+                datum1.detach().numpy(), datum1_original.detach().numpy(),
             )
-            assert id1_original == id1
 
-            datum2, label2, id2 = dataset2[i]
-            datum2_original_idx = np.argmax(dataset.targets == label2)
-            datum2_original, _, id2_original = dataset[datum2_original_idx]
+            label2, id2 = dataset2[i]
+            datum2_original_idx = np.argmax(dataset.ids == id2)
+            _, datum2_original_label, id2_original = dataset[datum2_original_idx]
 
-            np.testing.assert_array_equal(
-                datum2.detach().numpy(),
-                datum2_original.detach().numpy()[:, half_data_size:],
-            )
-            assert id2_original == id2
+            assert label2 == datum2_original_label
 
     def test_that_partition_removes_data(self):
         """
@@ -151,43 +152,5 @@ class TestPartition:
         assert 59_200 <= len(dataset1) <= 59_600
         assert 59_200 <= len(dataset2) <= 59_600
 
-        # Check same number of data and targets have been removed
-        assert dataset1.data.size(0) == dataset1.targets.size(0)
-        assert dataset2.data.size(0) == dataset2.targets.size(0)
-
-        # Check that we haven't lost data in other dimensions
-        dataset1_data_size = dataset1.data.size(1) * dataset1.data.size(2)
-        dataset2_data_size = dataset2.data.size(1) * dataset2.data.size(2)
-        original_dataset_data_size = self.dataset.data.size(1) * self.dataset.data.size(
-            2
-        )
-
-        assert dataset1_data_size + dataset2_data_size == original_dataset_data_size
-
-    def test_that_unique_ids_remain_attached_to_correct_data(self):
-        """
-        Check that IDs are not sorted differently to data/labels and are removed
-        if the data is
-        """
-        dataset1, dataset2 = partition_dataset(self.dataset)
-
-        # Check same number of data, targets, ids have been removed
-        assert dataset1.data.size(0) == dataset1.targets.size(0) == len(dataset1.ids)
-        assert dataset2.data.size(0) == dataset2.targets.size(0) == len(dataset2.ids)
-
-        # Check that IDs are unique
-        _, id1_counts = np.unique(dataset1.ids, return_counts=True)
-        assert np.max(id1_counts) == 1
-
-        _, id2_counts = np.unique(dataset2.ids, return_counts=True)
-        assert np.max(id2_counts) == 1
-
-        # Check that IDs still align with data and labels
-        # Check first 100 only to save time
-        for i in range(100):
-            _, label, id = dataset1[i]
-
-            id_original_index = np.where(dataset2.ids == id)[0]
-            if id_original_index.size:
-                # ID is in dataset2 as well, so we can compare labels
-                assert dataset2.targets[id_original_index[0]] == label
+        assert len(dataset1) == len(dataset1.ids)
+        assert len(dataset2) == len(dataset2.ids)


### PR DESCRIPTION
## Description
This PR changes the partition function from (top half of image, bottom half of image) to (image, labels). This is a simpler version of vertically partitioned data on which it will be easier to train a model.

This PR also introduces a dataloader which iterates through both partitions of the data

Fixes #18 

## How has this been tested?
- Implemented unit tests

## Checklist
- [X] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [X] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [X] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [X] My changes are covered by tests
