### PR TITLE
NewVerticalDataLoader

### DIFF
--- a/examples/Simple Vertically Partitioned SplitNN.ipynb
+++ b/examples/Simple Vertically Partitioned SplitNN.ipynb
@@ -123,10 +123,10 @@
     "from torchvision.datasets import MNIST\n",
     "from torchvision.transforms import ToTensor\n",
     "\n",
-    "from src.dataloader import PartitionDistributingDataLoader, NewVerticalDataLoader\n",
-    "from src.dataset import add_ids, partition_dataset\n",
+    "from src.dataloader import NewVerticalDataLoader\n",
+    "from src.dataset import add_ids\n",
     "\n",
-    "hook = sy.TorchHook(torch)\n"
+    "hook = sy.TorchHook(torch)"
    ]
   },
   {
@@ -135,20 +135,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# # Create dataset\n",
-    "# data = add_ids(MNIST)(\".\", download=True, transform=ToTensor())  # add_ids adds unique IDs to data points\n",
-    "\n",
-    "# # Split data\n",
-    "# data_partition1, data_partition2 = partition_dataset(data, remove_data=False, keep_order=True)\n",
-    "\n",
-    "# # Batch data\n",
-    "# dataloader = PartitionDistributingDataLoader(data_partition1, data_partition2, batch_size=128)\n",
-    "\n",
     "# Create dataset\n",
     "data = add_ids(MNIST)(\".\", download=True, transform=ToTensor())  # add_ids adds unique IDs to data points\n",
     "\n",
     "# Batch data\n",
-    "dataloader = NewVerticalDataLoader(data, batch_size=128)"
+    "dataloader = NewVerticalDataLoader(data, batch_size=128) # partition_dataset uses by default \"remove_data=False, keep_order=True\""
    ]
   },
   {
@@ -253,8 +244,7 @@
     "        running_loss += loss.get()\n",
     "\n",
     "    else:\n",
-    "#       print(\"Epoch {} - Training loss: {}\".format(i, running_loss/len(dataloader)))\n",
-    "        print(\"Epoch {} - Training loss: {}\".format(i, running_loss/469)) # Hardcoded for now. For 128 batch size this number should be 469."
+    "        print(\"Epoch {} - Training loss: {}\".format(i, running_loss/len(dataloader)))"
    ]
   },
   {
@@ -266,8 +256,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Labels pointing to:  (Wrapper)>[PointerTensor | me:96162582542 -> bob:96666190653]\n",
-      "Images pointing to:  (Wrapper)>[PointerTensor | me:73324609636 -> alice:89218641557]\n"
+      "Labels pointing to:  (Wrapper)>[PointerTensor | me:42341838847 -> bob:87239048952]\n",
+      "Images pointing to:  (Wrapper)>[PointerTensor | me:49156307882 -> alice:66623641152]\n"
      ]
     }
    ],

--- a/examples/Simple Vertically Partitioned SplitNN.ipynb
+++ b/examples/Simple Vertically Partitioned SplitNN.ipynb
@@ -123,7 +123,7 @@
     "from torchvision.datasets import MNIST\n",
     "from torchvision.transforms import ToTensor\n",
     "\n",
-    "from src.dataloader import PartitionDistributingDataLoader\n",
+    "from src.dataloader import PartitionDistributingDataLoader, NewVerticalDataLoader\n",
     "from src.dataset import add_ids, partition_dataset\n",
     "\n",
     "hook = sy.TorchHook(torch)\n"
@@ -135,14 +135,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# # Create dataset\n",
+    "# data = add_ids(MNIST)(\".\", download=True, transform=ToTensor())  # add_ids adds unique IDs to data points\n",
+    "\n",
+    "# # Split data\n",
+    "# data_partition1, data_partition2 = partition_dataset(data, remove_data=False, keep_order=True)\n",
+    "\n",
+    "# # Batch data\n",
+    "# dataloader = PartitionDistributingDataLoader(data_partition1, data_partition2, batch_size=128)\n",
+    "\n",
     "# Create dataset\n",
     "data = add_ids(MNIST)(\".\", download=True, transform=ToTensor())  # add_ids adds unique IDs to data points\n",
     "\n",
-    "# Split data\n",
-    "data_partition1, data_partition2 = partition_dataset(data, remove_data=False, keep_order=True)\n",
-    "\n",
     "# Batch data\n",
-    "dataloader = PartitionDistributingDataLoader(data_partition1, data_partition2, batch_size=128)"
+    "dataloader = NewVerticalDataLoader(data, batch_size=128)"
    ]
   },
   {
@@ -260,8 +266,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Labels pointing to:  (Wrapper)>[PointerTensor | me:72070217692 -> bob:32837817051]\n",
-      "Images pointing to:  (Wrapper)>[PointerTensor | me:59275959780 -> alice:6607304323]\n"
+      "Labels pointing to:  (Wrapper)>[PointerTensor | me:96162582542 -> bob:96666190653]\n",
+      "Images pointing to:  (Wrapper)>[PointerTensor | me:73324609636 -> alice:89218641557]\n"
      ]
     }
    ],

--- a/src/dataloader.py
+++ b/src/dataloader.py
@@ -1,11 +1,14 @@
 """
 Vertically partitioned dataloader
 """
+import sys
+sys.path.append('../')
 from typing import List, Tuple
 from uuid import UUID
 
 from torch.utils.data import DataLoader
 from torch.utils.data._utils.collate import default_collate
+from src.dataset import partition_dataset
 
 
 def id_collate_fn(batch: Tuple) -> List:
@@ -56,6 +59,26 @@ class PartitionDistributingDataLoader:
 
         self.dataloader1 = VerticalDataLoader(dataset1, *args, **kwargs)
         self.dataloader2 = VerticalDataLoader(dataset2, *args, **kwargs)
+
+    def __iter__(self):
+        return zip(self.dataloader1, self.dataloader2)
+
+class NewVerticalDataLoader:
+    """Dataloader which batches data from a complete
+    set of vertically-partitioned datasets
+    i.e. the images dataset AND the labels dataset
+    """
+
+    def __init__(self, dataset, *args, **kwargs):
+        
+        # Split data
+        self.data_partition1, self.data_partition2 = partition_dataset(dataset, remove_data=False, keep_order=True)
+
+        assert self.data_partition1.targets is None
+        assert self.data_partition2.data is None
+
+        self.dataloader1 = VerticalDataLoader(self.data_partition1, *args, **kwargs)
+        self.dataloader2 = VerticalDataLoader(self.data_partition2, *args, **kwargs)
 
     def __iter__(self):
         return zip(self.dataloader1, self.dataloader2)

--- a/src/dataloader.py
+++ b/src/dataloader.py
@@ -86,3 +86,6 @@ class NewVerticalDataLoader:
 
     def __iter__(self):
         return zip(self.dataloader1, self.dataloader2)
+
+    def __len__(self):
+        return (len(self.dataloader1) + len(self.dataloader2)) // 2

--- a/src/dataloader.py
+++ b/src/dataloader.py
@@ -73,7 +73,7 @@ class NewVerticalDataLoader:
 
     def __init__(self, dataset, *args, **kwargs):
 
-        # Split data
+        # Split datasets
         self.data_partition1, self.data_partition2 = partition_dataset(
             dataset, remove_data=False, keep_order=True
         )

--- a/src/dataloader.py
+++ b/src/dataloader.py
@@ -2,7 +2,8 @@
 Vertically partitioned dataloader
 """
 import sys
-sys.path.append('../')
+
+sys.path.append("../")
 from typing import List, Tuple
 from uuid import UUID
 
@@ -63,6 +64,7 @@ class PartitionDistributingDataLoader:
     def __iter__(self):
         return zip(self.dataloader1, self.dataloader2)
 
+
 class NewVerticalDataLoader:
     """Dataloader which batches data from a complete
     set of vertically-partitioned datasets
@@ -70,9 +72,11 @@ class NewVerticalDataLoader:
     """
 
     def __init__(self, dataset, *args, **kwargs):
-        
+
         # Split data
-        self.data_partition1, self.data_partition2 = partition_dataset(dataset, remove_data=False, keep_order=True)
+        self.data_partition1, self.data_partition2 = partition_dataset(
+            dataset, remove_data=False, keep_order=True
+        )
 
         assert self.data_partition1.targets is None
         assert self.data_partition2.data is None


### PR DESCRIPTION
## Description
The `NewVerticalDataLoader` class gets the dataset as input, creates 2 vertically-partitioned datasets, and returns them.

For now, it uses hardcoded `partition_dataset(dataset, remove_data=False, keep_order=True)`, in a future PR, it could take the `remove_data` and `keep_order` as arguments.

_I have tried to use the existing `VerticalDataLoader` and `PartitionDistributingDataLoader` classes in `dataloader.py` but I was getting errors, so I have just created a new class._

Created a `len` method on the `NewVerticalDataLoader` class, instead of using a hardcoded length as it was in the "Simple Vertically Partitioned SplitNN" Jupyter Notebook example.

Closes #5 
Closes #3 

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
