### PR TITLE
Fix version of PSI build to old commit

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -3,7 +3,7 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 git_repository(
    name = "org_openmined_psi",
    remote = "https://github.com/OpenMined/PSI",
-   branch = "master",
+   commit = "be9ea907c42a0e7304ffa33d8e572acb18de0f92",
    init_submodules = True,
 )
 
@@ -14,4 +14,3 @@ psi_preload()
 load("@org_openmined_psi//private_set_intersection:deps.bzl", "psi_deps")
 
 psi_deps()
-


### PR DESCRIPTION
## Description
Fix version of PSI build to a specific commit.
Pointing to latest master makes PyVertical liable to breaking from upstream bugs.

Fixes #36  

## How has this been tested?
- Ran `.github/workflows/scripts/build_psi.sh` - builds successfully (Ubuntu 18.04)
    - Build does not currently work using old WORKSPACE file due to upstream bug

## Checklist
- [X] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [X] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [X] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [X] My changes are covered by tests
