### PR TITLE
Refactor dataloader

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,22 +62,22 @@ To create a vertically partitioned dataset:
 from torchvision.datasets import MNIST
 from torchvision.transforms import ToTensor
 
-from src.dataloader import PartitionDistributingDataLoader
-from src.dataset import add_ids, partition_dataset
+from src.dataloader import VerticalDataLoader
+from src.dataset import add_ids
 from src.psi.util import compute_psi
 
 # Create dataset
 data = add_ids(MNIST)(".", download=True, transform=ToTensor())  # add_ids adds unique IDs to data points
 
-# Split data
-data_partition1, data_partition2 = partition_dataset(data, remove_data=False)
+# Partition and batch data
+dataloader = VerticalDataLoader(data, batch_size=128)
 
-# Compute private set intersection
-intersection = compute_psi(data_partition1.get_ids(), data_partition2.get_ids())
+# Compute private set intersections
+intersection1 = compute_psi(dataloader.dataloader1.dataset.get_ids(), dataloader.dataloader2.dataset.get_ids())
+intersection2 = compute_psi(dataloader.dataloader2.dataset.get_ids(), dataloader.dataloader1.dataset.get_ids())
 
-# Batch data
-dataloader = PartitionDistributingDataLoader(data_partition1, data_partition2, batch_size=128)
-dataloader.drop_non_intersecting(intersection)
+# Order data
+dataloader.drop_non_intersecting(intersection1, intersection2)
 
 for (data, ids1), (labels, ids2) in dataloader:
     # Train a model

--- a/examples/Simple Vertically Partitioned SplitNN.ipynb
+++ b/examples/Simple Vertically Partitioned SplitNN.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -32,7 +32,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -102,28 +102,38 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Falling back to insecure randomness since the required custom op could not be found for the installed version of TensorFlow. Fix this by compiling custom ops. Missing file was '/home/pavlito/miniconda3/envs/pyvertical-dev/lib/python3.7/site-packages/tf_encrypted/operations/secure_random/secure_random_module_tf_1.15.3.so'\n"
+      "Falling back to insecure randomness since the required custom op could not be found for the installed version of TensorFlow. Fix this by compiling custom ops. Missing file was '/home/tom/anaconda3/envs/pyvertical-dev/lib/python3.7/site-packages/tf_encrypted/operations/secure_random/secure_random_module_tf_1.15.3.so'\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "WARNING:tensorflow:From /home/tom/anaconda3/envs/pyvertical-dev/lib/python3.7/site-packages/tf_encrypted/session.py:24: The name tf.Session is deprecated. Please use tf.compat.v1.Session instead.\n",
+      "\n"
      ]
     }
    ],
    "source": [
     "import sys\n",
     "sys.path.append('../')\n",
+    "\n",
     "import torch\n",
     "from torchvision import datasets, transforms\n",
     "from torch import nn, optim\n",
-    "import syft as sy\n",
     "from torchvision.datasets import MNIST\n",
     "from torchvision.transforms import ToTensor\n",
     "\n",
-    "from src.dataloader import NewVerticalDataLoader\n",
+    "import syft as sy\n",
+    "\n",
+    "from src.dataloader import VerticalDataLoader\n",
     "from src.dataset import add_ids\n",
     "\n",
     "hook = sy.TorchHook(torch)"
@@ -131,7 +141,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -139,12 +149,12 @@
     "data = add_ids(MNIST)(\".\", download=True, transform=ToTensor())  # add_ids adds unique IDs to data points\n",
     "\n",
     "# Batch data\n",
-    "dataloader = NewVerticalDataLoader(data, batch_size=128) # partition_dataset uses by default \"remove_data=False, keep_order=True\""
+    "dataloader = VerticalDataLoader(data, batch_size=128) # partition_dataset uses by default \"remove_data=False, keep_order=True\""
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -187,7 +197,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -212,39 +222,7 @@
     "    #6) Change the weights\n",
     "    splitNN.step()\n",
     "    \n",
-    "    return loss"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Epoch 0 - Training loss: 1.1379796266555786\n",
-      "Epoch 1 - Training loss: 0.38587328791618347\n",
-      "Epoch 2 - Training loss: 0.3184337019920349\n",
-      "Epoch 3 - Training loss: 0.2822173535823822\n",
-      "Epoch 4 - Training loss: 0.2552659809589386\n"
-     ]
-    }
-   ],
-   "source": [
-    "for i in range(epochs):\n",
-    "    running_loss = 0        \n",
-    "    for (data, ids1), (labels, ids2) in dataloader:\n",
-    "        # Train a model\n",
-    "        data = data.send(models[0].location)\n",
-    "        data = data.view(data.shape[0], -1)\n",
-    "        labels = labels.send(models[-1].location)\n",
-    "        loss = train(data, labels, splitNN)\n",
-    "        running_loss += loss.get()\n",
-    "\n",
-    "    else:\n",
-    "        print(\"Epoch {} - Training loss: {}\".format(i, running_loss/len(dataloader)))"
+    "    return loss, pred"
    ]
   },
   {
@@ -256,8 +234,48 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Labels pointing to:  (Wrapper)>[PointerTensor | me:42341838847 -> bob:87239048952]\n",
-      "Images pointing to:  (Wrapper)>[PointerTensor | me:49156307882 -> alice:66623641152]\n"
+      "Epoch 0 - Training loss: 1.138 - Accuracy: 73.363\n",
+      "Epoch 1 - Training loss: 0.386 - Accuracy: 89.078\n",
+      "Epoch 2 - Training loss: 0.318 - Accuracy: 90.933\n",
+      "Epoch 3 - Training loss: 0.282 - Accuracy: 91.933\n",
+      "Epoch 4 - Training loss: 0.255 - Accuracy: 92.685\n"
+     ]
+    }
+   ],
+   "source": [
+    "for i in range(epochs):\n",
+    "    running_loss = 0\n",
+    "    correct_preds = 0\n",
+    "    total_preds = 0\n",
+    "\n",
+    "    for (data, ids1), (labels, ids2) in dataloader:\n",
+    "        # Train a model\n",
+    "        data = data.send(models[0].location)\n",
+    "        data = data.view(data.shape[0], -1)\n",
+    "        labels = labels.send(models[-1].location)\n",
+    "\n",
+    "        # Call model\n",
+    "        loss, preds = train(data, labels, splitNN)\n",
+    "\n",
+    "        # Collect statistics\n",
+    "        running_loss += loss.get()\n",
+    "        correct_preds += preds.max(1)[1].eq(labels).sum().get().item()\n",
+    "        total_preds += preds.get().size(0)\n",
+    "\n",
+    "    print(f\"Epoch {i} - Training loss: {running_loss/len(dataloader):.3f} - Accuracy: {100*correct_preds/total_preds:.3f}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Labels pointing to:  (Wrapper)>[PointerTensor | me:9479251 -> bob:3711002838]\n",
+      "Images pointing to:  (Wrapper)>[PointerTensor | me:89439785830 -> alice:85458007243]\n"
      ]
     }
    ],
@@ -279,18 +297,6 @@
    "display_name": "Python 3",
    "language": "python",
    "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.7.6"
   }
  },
  "nbformat": 4,

--- a/src/dataloader.py
+++ b/src/dataloader.py
@@ -81,7 +81,7 @@ class VerticalDataLoader:
         self.dataloader1.dataset.data = self.dataloader1.dataset.data[intersection1]
         self.dataloader1.dataset.ids = self.dataloader1.dataset.ids[intersection1]
 
-        self.dataloader2.dataset.targets = elf.dataloader2.dataset.targets[
+        self.dataloader2.dataset.targets = self.dataloader2.dataset.targets[
             intersection2
         ]
         self.dataloader2.dataset.ids = self.dataloader2.dataset.ids[intersection2]

--- a/tests/test_dataloader.py
+++ b/tests/test_dataloader.py
@@ -108,7 +108,7 @@ class TestVerticalDataLoader:
         dataloader.drop_non_intersecting(intersection1, intersection2)
 
         assert len(dataloader.dataloader1.dataset.data) == 4
-        assert dataloader.dataloader1.dataset.ids == ids1
+        assert (dataloader.dataloader1.dataset.ids == ids1).all()
 
-        assert len(dataloader.dataloader2.data.targets) == 4
-        assert dataloader.dataloader2.dataset.ids == ids2
+        assert len(dataloader.dataloader2.dataset.targets) == 4
+        assert (dataloader.dataloader2.dataset.ids == ids2).all()

--- a/tests/test_dataloader.py
+++ b/tests/test_dataloader.py
@@ -8,15 +8,17 @@ import torch
 import torchvision.transforms as transforms
 from torchvision.datasets import MNIST
 
-from src.dataloader import VerticalDataLoader, PartitionDistributingDataLoader
+from src.dataloader import VerticalDataLoader, SinglePartitionDataLoader
 from src.dataset import add_ids, partition_dataset
 
 
-class TestVerticalDataLoader:
+class TestSinglePartitionDataset:
     @classmethod
     def setup_class(cls):
         dataset = add_ids(MNIST)(
-            "./TestVerticalDataset", download=True, transform=transforms.ToTensor(),
+            "./TestSinglePartitionDataset",
+            download=True,
+            transform=transforms.ToTensor(),
         )
 
         dataset1, dataset2 = partition_dataset(dataset)
@@ -25,17 +27,17 @@ class TestVerticalDataLoader:
 
     @classmethod
     def teardown_class(cls):
-        rmtree("./TestVerticalDataset")
+        rmtree("./TestSinglePartitionDataset")
 
     def test_that_vertical_dataloader_only_returns_data_which_is_not_none(self):
-        dataloader1 = VerticalDataLoader(self.dataset1, batch_size=100)
+        dataloader1 = SinglePartitionDataLoader(self.dataset1, batch_size=100)
         for results in dataloader1:
             assert len(results) == 2
 
             # IDs should have been converted to string
             assert isinstance(results[1][0], str)
 
-        dataloader2 = VerticalDataLoader(self.dataset2, batch_size=100)
+        dataloader2 = SinglePartitionDataLoader(self.dataset2, batch_size=100)
         for results in dataloader2:
             assert len(results) == 2
 
@@ -43,29 +45,19 @@ class TestVerticalDataLoader:
             assert isinstance(results[1][0], str)
 
 
-class TestPartitionDistributingDataLoader:
+class TestVerticalDataLoader:
     @classmethod
     def setup_class(cls):
-        dataset = add_ids(MNIST)(
-            "./TestPartitionDistributingDataLoader",
-            download=True,
-            transform=transforms.ToTensor(),
+        cls.dataset = add_ids(MNIST)(
+            "./TestVerticalDataLoader", download=True, transform=transforms.ToTensor(),
         )
-
-        dataset1, dataset2 = partition_dataset(
-            dataset, remove_data=False,
-        )  # for now, until PSI allows us to re-balance datasets
-        cls.dataset1 = dataset1
-        cls.dataset2 = dataset2
 
     @classmethod
     def teardown_class(cls):
-        rmtree("./TestPartitionDistributingDataLoader")
+        rmtree("./TestVerticalDataLoader")
 
     def test_vertical_dataloader_batches_partitioned_datasets(self):
-        dataloader = PartitionDistributingDataLoader(
-            self.dataset1, self.dataset2, batch_size=100
-        )
+        dataloader = VerticalDataLoader(self.dataset, batch_size=100)
 
         for results in dataloader:
             assert len(results) == 2  # dataset1_data, dataset2_data
@@ -80,40 +72,43 @@ class TestPartitionDistributingDataLoader:
             assert isinstance(results[0][1][0], str)
             assert isinstance(results[1][1][0], str)
 
-    def test_that_dataset1_must_not_have_targets(self):
-        with pytest.raises(AssertionError):
-            dataloader = PartitionDistributingDataLoader(
-                self.dataset2, self.dataset2, batch_size=100
-            )
-
-    def test_that_dataset2_must_not_have_data(self):
-        with pytest.raises(AssertionError):
-            dataloader = PartitionDistributingDataLoader(
-                self.dataset1, self.dataset1, batch_size=100
-            )
-
-    def test_drop_non_intersecting_removes_correct_elements(self):
-        dataloader = PartitionDistributingDataLoader(
-            self.dataset1, self.dataset2, batch_size=100
-        )
+    def test_drop_non_intersecting_removes_elements(self):
+        dataloader = VerticalDataLoader(self.dataset, batch_size=100)
         sample_datapoint = dataloader.dataloader1.dataset.data[0]
         intersection = [0, 1, 2]
 
-        dataloader.drop_non_intersecting(intersection)
+        dataloader.drop_non_intersecting(intersection, intersection)
 
-        assert 3 == len(dataloader.dataloader1.dataset.data)
-        assert 3 == len(dataloader.dataloader1.dataset.ids)
-        assert 3 == len(dataloader.dataloader2.dataset.ids)
+        assert len(dataloader.dataloader1.dataset.data) == 3
+        assert len(dataloader.dataloader1.dataset.ids) == 3
+        assert len(dataloader.dataloader2.dataset.targets) == 3
+        assert len(dataloader.dataloader2.dataset.ids) == 3
         assert torch.equal(sample_datapoint, dataloader.dataloader1.dataset.data[0])
 
     def test_drop_non_intersecting_removes_all_elements_with_empty_intersection(self):
-        dataloader = PartitionDistributingDataLoader(
-            self.dataset1, self.dataset2, batch_size=100
-        )
+        dataloader = VerticalDataLoader(self.dataset, batch_size=100)
         intersection = []
 
-        dataloader.drop_non_intersecting(intersection)
+        dataloader.drop_non_intersecting(intersection, intersection)
 
-        assert 0 == len(dataloader.dataloader1.dataset.data)
-        assert 0 == len(dataloader.dataloader1.dataset.ids)
-        assert 0 == len(dataloader.dataloader2.dataset.ids)
+        assert len(dataloader.dataloader1.dataset.data) == 0
+        assert len(dataloader.dataloader1.dataset.ids) == 0
+        assert len(dataloader.dataloader2.dataset.targets) == 0
+        assert len(dataloader.dataloader2.dataset.ids) == 0
+
+    def test_datasets_have_same_ids_after_drop_non_intersecting(self):
+        dataloader = VerticalDataLoader(self.dataset, batch_size=128)
+
+        intersection1 = [0, 1, 5, 10]
+        ids1 = [dataloader.dataloader1.dataset.ids[i] for i in intersection1]
+
+        intersection2 = [7, 10, 12, 1]
+        ids2 = [dataloader.dataloader2.dataset.ids[i] for i in intersection2]
+
+        dataloader.drop_non_intersecting(intersection1, intersection2)
+
+        assert len(dataloader.dataloader1.dataset.data) == 4
+        assert dataloader.dataloader1.dataset.ids == ids1
+
+        assert len(dataloader.dataloader2.data.targets) == 4
+        assert dataloader.dataloader2.dataset.ids == ids2

--- a/tests/test_psi.py
+++ b/tests/test_psi.py
@@ -5,16 +5,20 @@ import pytest
 
 from src.psi.util import compute_psi
 
+
 @pytest.mark.parametrize(
     "test_input,expected",
     [
-        (([str(i) for i in range(10)], [str(i*2) for i in range(10)]), [0, 2, 4, 6, 8]),
-        ((['0'], ['0']), [0]),
-        ((['1'], ['2']), []),
-        ((['1'], []), []),
-        (([], ['1']), []),
+        (
+            ([str(i) for i in range(10)], [str(i * 2) for i in range(10)]),
+            [0, 2, 4, 6, 8],
+        ),
+        ((["0"], ["0"]), [0]),
+        ((["1"], ["2"]), []),
+        ((["1"], []), []),
+        (([], ["1"]), []),
         (([], []), []),
-    ]
+    ],
 )
 def test_compute_psi_returns_correct_indices(test_input, expected):
     assert expected == compute_psi(*test_input)


### PR DESCRIPTION
## Description
- Rename `VerticalDataloader` to `SinglePartitionDataLoader`
- Rename `NewVerticalDataLoader` to `VerticalDataLoader`
- Remove `PartitionDistributingDataLoader`
- Add drop indices functionality to `(New)VerticalDataLoader`
- Extend drop indices functionality to take different indices for datasets 1 and 2
- Update README example
- Update SplitNN notebook
- Slightly extend unit tests on dataloader drop indices functionality

Fixes #32 

## How has this been tested?
- Unit tests
- Manually ran notebook to check it works

## Checklist
- [X] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [X] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [X] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [X] My changes are covered by tests
