### PR TITLE
Sort ids in dataloader

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ intersection2 = compute_psi(dataloader.dataloader2.dataset.get_ids(), dataloader
 
 # Order data
 dataloader.drop_non_intersecting(intersection1, intersection2)
+dataloader.sort_by_ids()
 
 for (data, ids1), (labels, ids2) in dataloader:
     # Train a model

--- a/src/dataloader.py
+++ b/src/dataloader.py
@@ -57,7 +57,7 @@ class VerticalDataLoader:
 
         # Split datasets
         self.data_partition1, self.data_partition2 = partition_dataset(
-            dataset, remove_data=False, keep_order=True
+            dataset, remove_data=False, keep_order=False
         )
 
         assert self.data_partition1.targets is None
@@ -85,3 +85,10 @@ class VerticalDataLoader:
             intersection2
         ]
         self.dataloader2.dataset.ids = self.dataloader2.dataset.ids[intersection2]
+
+    def sort_by_ids(self) -> None:
+        """
+        Sort each dataset by ids
+        """
+        self.dataloader1.dataset.sort_by_ids()
+        self.dataloader2.dataset.sort_by_ids()

--- a/src/dataset.py
+++ b/src/dataset.py
@@ -64,6 +64,21 @@ def add_ids(cls):
             """Return a list of the ids of this dataset."""
             return [str(id_) for id_ in self.ids]
 
+        def sort_by_ids(self):
+            """
+            Sort the dataset by IDs in ascending order
+            """
+            ids = self.get_ids()
+            sorted_idxs = np.argsort(ids)
+
+            if self.data is not None:
+                self.data = self.data[sorted_idxs]
+
+            if self.targets is not None:
+                self.targets = self.targets[sorted_idxs]
+
+            self.ids = self.ids[sorted_idxs]
+
     return VerticalDataset
 
 

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -6,6 +6,7 @@ from shutil import rmtree
 import uuid
 
 import numpy as np
+import pytest
 import torch
 import torchvision.transforms as transforms
 from torchvision.datasets import MNIST
@@ -122,3 +123,43 @@ class TestPartition:
     def test_get_ids_returns_list_of_strings(self):
         for id_ in self.dataset.get_ids():
             assert isinstance(id_, str)
+
+    def test_sort_by_ids_sorts_data(self):
+        dataset1, _ = partition_dataset(self.dataset)
+
+        data_unsorted = dataset1.data.clone().numpy()
+        ids1_unsorted = dataset1.get_ids()
+        ids1_sorted = np.sort(ids1_unsorted)
+
+        # Check it's not sorted to start with
+        with pytest.raises(AssertionError):
+            np.testing.assert_array_equal(ids1_unsorted, ids1_sorted)
+
+        # Sort
+        dataset1.sort_by_ids()
+        data_after_sort = dataset1.data.clone().numpy()
+
+        np.testing.assert_array_equal(dataset1.get_ids(), ids1_sorted)
+
+        # Check that data has also been shuffled
+        with pytest.raises(AssertionError):
+            np.testing.assert_array_equal(data_after_sort, data_unsorted)
+
+    def test_sort_by_ids_sorts_targets(self):
+        _, dataset2 = partition_dataset(self.dataset)
+
+        targets_unsorted = dataset2.targets.clone().numpy()
+        ids2_unsorted = dataset2.get_ids()
+        ids2_sorted = np.sort(ids2_unsorted)
+
+        with pytest.raises(AssertionError):
+            np.testing.assert_array_equal(ids2_unsorted, ids2_sorted)
+
+        # Sort
+        dataset2.sort_by_ids()
+        targets_after_sort = dataset2.targets.clone().numpy()
+
+        np.testing.assert_array_equal(dataset2.get_ids(), ids2_sorted)
+
+        with pytest.raises(AssertionError):
+            np.testing.assert_array_equal(targets_after_sort, targets_unsorted)


### PR DESCRIPTION
## Description
`compute_psi` does not sort data passed to it. This PR adds a method to datasets to sort the data by the IDs.

There is no associated issue as this bug was just discovered.

## Affected Dependencies
-

## How has this been tested?
- In the example notebook, print IDs, data and targets, then run call `sort_by_ids` on the `VerticalDataLoader` and print them again. All objects should have been re-ordered
- Unit tests for `dataset.sort_by_ids` have been added

## Checklist
- [X] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [X] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [X] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [X] My changes are covered by tests
