### PR TITLE
Test PR to fix failing builds

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -3,7 +3,7 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 git_repository(
    name = "org_openmined_psi",
    remote = "https://github.com/OpenMined/PSI",
-   commit = "be9ea907c42a0e7304ffa33d8e572acb18de0f92",
+   branch = "master",
    init_submodules = True,
 )
 


### PR DESCRIPTION
## Description
Changed the workspace file to point to master branch of PSI instead of a specific commit.
This is an attempt to fix the failing bazel builds in github CI which started occurring a few days ago.
This fix attempt is not based on anything concrete - we're just trying something

Fixes #42 


## Affected Dependencies
`PSI` code now points to `master` branch, not a specific commit.
This makes PyVertical liable to upstream breaking changes
