### PR TITLE
Update workspace to latest PSI commit

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -3,7 +3,7 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 git_repository(
    name = "org_openmined_psi",
    remote = "https://github.com/OpenMined/PSI",
-   branch = "fix_c++_version",
+   commit = "ca2866e3c70a018ed9a5a2e7af5bcbd31dc49df9",
    init_submodules = True,
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -3,7 +3,7 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 git_repository(
    name = "org_openmined_psi",
    remote = "https://github.com/OpenMined/PSI",
-   commit = "be9ea907c42a0e7304ffa33d8e572acb18de0f92",
+   commit = "2110b0c78aaf535f0f154541a5239ae1d4876023",
    init_submodules = True,
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -3,7 +3,7 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 git_repository(
    name = "org_openmined_psi",
    remote = "https://github.com/OpenMined/PSI",
-   commit = "2110b0c78aaf535f0f154541a5239ae1d4876023",
+   branch = "fix_c++_version",
    init_submodules = True,
 )
 


### PR DESCRIPTION
## Description
Updates WORKSPACE to build from latest PSI commit. PSI repo has pinned their dependency which was causing a checksum error in PyVertical (https://github.com/OpenMined/PSI/issues/72)

#52 changed the workspace to a fork of PSI to get around existing bugs. This PR should be merged when those bugs are fixed in OpenMined/PSI

## Affected Dependencies
Updates PSI

## How has this been tested?
- Build locally with `.github/workflows/scripts/build_psi.sh`

## Checklist
- [X] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [X] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [X] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [X] My changes are covered by tests
