### PR TITLE
Change workspace to point to fork

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,8 +2,8 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 git_repository(
    name = "org_openmined_psi",
-   remote = "https://github.com/OpenMined/PSI",
-   commit = "be9ea907c42a0e7304ffa33d8e572acb18de0f92",
+   remote = "https://github.com/TTitcombe/PSI",
+   branch = "fix_versions",
    init_submodules = True,
 )
 


### PR DESCRIPTION
## Description
Changes workspace file to point to a branch on my fork, which has the fix for the checksum bug, but has removed the protobuf code which is causing other issues.

When the protobuf bug is fixed, switch back to OpenMined/PSI

Fixes #42 

## Affected Dependencies
PSi version

## How has this been tested?
- Build with `.github/workflows/scripts/build_psi.sh`

## Checklist
- [X] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [X] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [X] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [X] My changes are covered by tests
