### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+FROM python:3.8
+
+LABEL version="0.1.0"
+LABEL maintainer="OpenMined"
+
+COPY . /pyvertical
+WORKDIR /pyvertical
+
+# Setup bazel
+# See https://docs.bazel.build/versions/master/install-ubuntu.html
+## 1. Add bazel distribution
+RUN apt install curl gnupg
+RUN curl -f https://bazel.build/bazel-release.pub.gpg | apt-key add -
+RUN echo "deb [arch=amd64] https://storage.googleapis.com/bazel-apt stable jdk1.8" | tee /etc/apt/sources.list.d/bazel.list
+
+## 2. Install
+RUN apt update && apt install bazel
+
+# Setup PSI
+RUN .github/workflows/scripts/build_psi.sh
+
+# Setup environment
+RUN pip install -r requirements.txt
+RUN pip install jupyterlab
+
+# Expose port for jupyter lab
+EXPOSE 8888
+
+# Enter into jupyter lab
+ENTRYPOINT ["jupyter", "lab","--ip=0.0.0.0","--allow-root"]

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ This project is written in Python.
 The work is displayed in jupyter notebooks.
 
 ### Environment
+
 To install the dependencies,
 we recommend using [Conda]:
 1. Clone this repository
@@ -72,6 +73,7 @@ In the future,
 all packages will be moved into the `environment.yml`.
 
 ### PSI
+
 In order to use [PSI](https://github.com/OpenMined/PSI) with PyVertical,
 you need to install [bazel](https://www.bazel.build/) to build the necessary Python bindings for the C++ core.
 After you have installed bazel, run the build script with `.github/workflows/build-psi.sh`.
@@ -79,7 +81,18 @@ After you have installed bazel, run the build script with `.github/workflows/bui
 This should generate a `_psi_bindings.so` file
 and place it in `src/psi/`.
 
+### Docker
+
+You can instead opt to use Docker.
+
+To run:
+
+1. Build the image with `docker build -t pyvertical:latest .`
+1. Launch a container with `docker run -it -p 8888:8888 pyvertical:latest`
+  - Defaults to launching jupyter lab
+
 ## Usage
+
 Check out
 [`examples/PyVertical Example.ipynb`](examples/PyVertical%20Example.ipynb)
 to see `PyVertical` in action.


### PR DESCRIPTION
## Description
This PR adds a Dockerfile (built from python:3.8 image) for people to use to run PyVertical. This should help people get around PSI compilation issues they may have on their local machines

Fixes #55 

## Affected Dependencies
None

## How has this been tested?
- Built the image with `docker build -t pyvertical:latest .`
- Ran the container with `docker run -p 8888:8888 -it pyvertical:latest`
  - Launches jupyter lab

## Checklist
- [X] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [X] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [X] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [X] My changes are covered by tests
