### PR TITLE
Client server psi

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
+          pip install -r requirements.txt --no-cache-dir
           pip install -U pytest
           pip install flake8 black
           pip install mypy

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN apt update && apt install bazel
 RUN .github/workflows/scripts/build_psi.sh
 
 # Setup environment
-RUN pip install -r requirements.txt
+RUN pip install -r requirements.txt --no-cache-dir
 RUN pip install jupyterlab
 
 # Expose port for jupyter lab

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ all packages will be moved into the `environment.yml`.
 
 In order to use [PSI](https://github.com/OpenMined/PSI) with PyVertical,
 you need to install [bazel](https://www.bazel.build/) to build the necessary Python bindings for the C++ core.
-After you have installed bazel, run the build script with `.github/workflows/build-psi.sh`.
+After you have installed bazel, run the build script with `.github/workflows/scripts/build-psi.sh`.
 
 This should generate a `_psi_bindings.so` file
 and place it in `src/psi/`.

--- a/src/psi/util.py
+++ b/src/psi/util.py
@@ -72,27 +72,3 @@ class Client:
             The intersection set (List[str]) of client and server items
         """
         return self._client.GetIntersection(setup, response)
-
-
-def compute_psi(client_items, server_items, fpr=1e-9):
-    """Compute the private set intersection of `client_items` and `server_items`.
-
-    Args:
-        client_items (List[str]) : The items provided by the client
-        server_items (List[str]) : The items provided by the server
-        fpr (float) : The false positive ratio
-
-    Returns:
-        The intersection set (List[str]) of client and server items
-    """
-    if len(client_items) == 0 or len(server_items) == 0:
-        return []
-
-    c = client.CreateWithNewKey(True)
-    s = server.CreateWithNewKey(True)
-
-    setup = s.CreateSetupMessage(fpr, len(client_items), server_items)
-    request = c.CreateRequest(client_items)
-    resp = s.ProcessRequest(request)
-
-    return c.GetIntersection(setup, resp)

--- a/src/psi/util.py
+++ b/src/psi/util.py
@@ -5,6 +5,8 @@ from . import client, server
 
 class Server:
     def __init__(self, server_items, fpr=1e-9):
+        if len(server_items) == 0:
+            raise RuntimeError("Server items cannot be empty")
         reveal_intersection = True
         self._server = server.CreateWithNewKey(reveal_intersection)
         self._items = server_items
@@ -20,6 +22,8 @@ class Server:
 
 class Client:
     def __init__(self, client_items):
+        if len(client_items) == 0:
+            raise RuntimeError("Server items cannot be empty")
         reveal_intersection = True
         self._client = client.CreateWithNewKey(reveal_intersection)
         self._items = client_items

--- a/src/psi/util.py
+++ b/src/psi/util.py
@@ -4,7 +4,17 @@ from . import client, server
 
 
 class Server:
+    """
+    Class to represent the server in a client/server PSI model.
+    """
+
     def __init__(self, server_items, fpr=1e-9):
+        """
+        Args:
+            server_items (List[str]) : The items provided by the server
+            fpr (float) : The false positive ratio
+        """
+
         if len(server_items) == 0:
             raise RuntimeError("Server items cannot be empty")
         reveal_intersection = True
@@ -13,6 +23,20 @@ class Server:
         self._fpr = fpr
 
     def process_request(self, request, len_client_items):
+        """
+        Return the setup and corresponding response for the client to compute
+        the private set intersection.
+
+        Args:
+            request (_psi_bindings.PsiProtoRequest): The client request
+            len_client_items (int): The length of the client items
+
+        Returns:
+            A tuple of (setup, response) with:
+            setup (_psi_bindings.PsiProtoServerSetup): The server setup
+            response (_psi_bindings.PsiProtoResponse): The server response
+        """
+        breakpoint()
         setup = self._server.CreateSetupMessage(
             self._fpr, len_client_items, self._items
         )
@@ -21,7 +45,15 @@ class Server:
 
 
 class Client:
+    """
+    Class to represent the client in a client/server PSI model.
+    """
+
     def __init__(self, client_items):
+        """
+        Args:
+            client_items (List[str]) : The items provided by the client
+        """
         if len(client_items) == 0:
             raise RuntimeError("Server items cannot be empty")
         reveal_intersection = True
@@ -30,6 +62,16 @@ class Client:
         self.request = self._client.CreateRequest(client_items)
 
     def compute_intersection(self, setup, response):
+        """
+        Return the intersection of client and server items.
+
+        Args:
+            setup (_psi_bindings.PsiProtoServerSetup): The server setup
+            response (_psi_bindings.PsiProtoResponse): The server response
+
+        Returns:
+            The intersection set (List[str]) of client and server items
+        """
         return self._client.GetIntersection(setup, response)
 
 

--- a/src/psi/util.py
+++ b/src/psi/util.py
@@ -3,6 +3,32 @@
 from . import client, server
 
 
+class Server:
+    def __init__(self, server_items, fpr=1e-9):
+        reveal_intersection = True
+        self._server = server.CreateWithNewKey(reveal_intersection)
+        self._items = server_items
+        self._fpr = fpr
+
+    def process_request(self, request, len_client_items):
+        setup = self._server.CreateSetupMessage(
+            self._fpr, len_client_items, self._items
+        )
+        response = self._server.ProcessRequest(request)
+        return setup, response
+
+
+class Client:
+    def __init__(self, client_items):
+        reveal_intersection = True
+        self._client = client.CreateWithNewKey(reveal_intersection)
+        self._items = client_items
+        self.request = self._client.CreateRequest(client_items)
+
+    def compute_intersection(self, setup, response):
+        return self._client.GetIntersection(setup, response)
+
+
 def compute_psi(client_items, server_items, fpr=1e-9):
     """Compute the private set intersection of `client_items` and `server_items`.
 

--- a/src/psi/util.py
+++ b/src/psi/util.py
@@ -36,7 +36,6 @@ class Server:
             setup (_psi_bindings.PsiProtoServerSetup): The server setup
             response (_psi_bindings.PsiProtoResponse): The server response
         """
-        breakpoint()
         setup = self._server.CreateSetupMessage(
             self._fpr, len_client_items, self._items
         )

--- a/tests/test_psi.py
+++ b/tests/test_psi.py
@@ -15,21 +15,11 @@ from src.psi.util import Client, Server
         ),
         ((["0"], ["0"]), [0]),
         ((["1"], ["2"]), []),
-        ((["1"], []), []),
-        (([], ["1"]), []),
-        (([], []), []),
     ],
 )
 def test_compute_intersection_returns_correct_indices(test_input, expected):
     client_items = test_input[0]
     server_items = test_input[1]
-
-    # Handle special case of empty client or server items
-    if len(client_items) == 0 or len(server_items) == 0:
-        with pytest.raises(RuntimeError):
-            client = Client(client_items)
-            server = Server(server_items)
-        return
 
     client = Client(client_items)
     server = Server(server_items)
@@ -38,3 +28,17 @@ def test_compute_intersection_returns_correct_indices(test_input, expected):
     intersection = client.compute_intersection(setup, response)
 
     assert expected == intersection
+
+
+@pytest.mark.parametrize(
+    "test_input,expected", [((["1"], []), []), (([], ["1"]), []), (([], []), []),],
+)
+def test_compute_intersection_returns_correct_indices_with_empty_items(
+    test_input, expected
+):
+    client_items = test_input[0]
+    server_items = test_input[1]
+
+    with pytest.raises(RuntimeError):
+        client = Client(client_items)
+        server = Server(server_items)

--- a/tests/test_psi.py
+++ b/tests/test_psi.py
@@ -3,7 +3,7 @@ Test code in src/psi
 """
 import pytest
 
-from src.psi.util import compute_psi
+from src.psi.util import Client, Server
 
 
 @pytest.mark.parametrize(
@@ -20,5 +20,21 @@ from src.psi.util import compute_psi
         (([], []), []),
     ],
 )
-def test_compute_psi_returns_correct_indices(test_input, expected):
-    assert expected == compute_psi(*test_input)
+def test_compute_intersection_returns_correct_indices(test_input, expected):
+    client_items = test_input[0]
+    server_items = test_input[1]
+
+    # Handle special case of empty client or server items
+    if len(client_items) == 0 or len(server_items) == 0:
+        with pytest.raises(RuntimeError):
+            client = Client(client_items)
+            server = Server(server_items)
+        return
+
+    client = Client(client_items)
+    server = Server(server_items)
+
+    setup, response = server.process_request(client.request, len(client_items))
+    intersection = client.compute_intersection(setup, response)
+
+    assert expected == intersection


### PR DESCRIPTION
## Description
In the current state, it could seem to users that the computation of the PSI is done on the same client. I introduced two separate classes `Client`  and `Server` that better reflect the client/server model of PSI to make it more obvious that the data does not reside on the same machines.

## Affected Dependencies
None

## How has this been tested?
- I adjusted the existing tests with the new interface while keeping the same test input as before

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests

This closes #54 since IDs don't have to be encrypted because the encryption is done on the PSI by the client and the server.