### PR TITLE
Check import formatting in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt --no-cache-dir
           pip install -U pytest
-          pip install flake8 black mypy coverage
+          pip install flake8 black mypy coverage isort
       - name: Run tests
         timeout-minutes: 15
         run: python -m pytest tests/
@@ -35,6 +35,8 @@ jobs:
         run: black --check src
       - name: Check type hints
         run: mypy src --ignore-missing-imports
+      - name: Check import formatting
+        run: isort src/ -c -v
   OtherOS:
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,9 @@
+[settings]
+profile=black
+force_single_line=True
+remove_redundant_aliases=True
+default_section=THIRDPARTY
+lines_between_types=0
+force_sort_within_sections=True
+force_grid_wrap=True
+honor_noqa=True

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ For major changes,
 please open an issue first to discuss what you would like to change.
 
 Read the OpenMined
-[contributing guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md)
+[contributing guidelines][contrib]
 and [styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
 for more information.
 
@@ -170,14 +170,14 @@ To run the tests manually:
 1. In the command line, navigate to the root of this repository
 1. Run `python -m pytest`
 
-CI also checks the code conforms to [`flake8`][flake8] standards
-and [`black`][black] formatting.
+CI also checks the code is formatting according to [contributing guidelines][contrib].
 
 ## License
 [Apache License 2.0](https://choosealicense.com/licenses/apache-2.0/)
 
 [black]: https://black.readthedocs.io/en/stable/
 [conda]: https://docs.conda.io/en/latest/
+[contrib]: https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md
 [flake8]: https://flake8.pycqa.org/en/latest/index.html#quickstart
 [psi]: https://www.github.com/OpenMined/PSI
 [pytest]: https://docs.pytest.org/en/latest/contents.html

--- a/src/dataloader.py
+++ b/src/dataloader.py
@@ -1,13 +1,12 @@
 """
 Dataloaders for vertically partitioned data
 """
-from typing import List
-
 from typing import List, Tuple
 from uuid import UUID
 
 from torch.utils.data import DataLoader
 from torch.utils.data._utils.collate import default_collate
+
 from src.utils import partition_dataset
 
 

--- a/src/dataloader.py
+++ b/src/dataloader.py
@@ -1,7 +1,8 @@
 """
 Dataloaders for vertically partitioned data
 """
-from typing import List, Tuple
+from typing import List
+from typing import Tuple
 from uuid import UUID
 
 from torch.utils.data import DataLoader

--- a/src/future/__init__.py
+++ b/src/future/__init__.py
@@ -1,1 +1,2 @@
-from .dataset import PartitionedDataset, VerticalDataset
+from .dataset import PartitionedDataset
+from .dataset import VerticalDataset

--- a/src/future/dataset.py
+++ b/src/future/dataset.py
@@ -5,8 +5,8 @@ Build from syft FederatedDatasets
 import logging
 
 import syft as sy
-import torch
 from syft.frameworks.torch import fl
+import torch
 
 logger = logging.getLogger(__name__)
 

--- a/src/future/dataset.py
+++ b/src/future/dataset.py
@@ -4,10 +4,9 @@ Build from syft FederatedDatasets
 """
 import logging
 
-import torch
 import syft as sy
+import torch
 from syft.frameworks.torch import fl
-
 
 logger = logging.getLogger(__name__)
 

--- a/src/psi/util.py
+++ b/src/psi/util.py
@@ -1,5 +1,6 @@
 """This module contains utility functions that expose functionality of PSI."""
-from openmined_psi import client, server
+from openmined_psi import client
+from openmined_psi import server
 
 
 class Server:

--- a/src/splitnn.py
+++ b/src/splitnn.py
@@ -7,9 +7,9 @@ Worker 2 has a segment of the model and the Labels
 """
 
 
+import syft as sy
 import torch
 from torch import nn
-import syft as sy
 
 hook = sy.TorchHook(torch)
 

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -1,1 +1,2 @@
-from .split_data import add_ids, partition_dataset
+from .split_data import add_ids
+from .split_data import partition_dataset

--- a/src/utils/split_data.py
+++ b/src/utils/split_data.py
@@ -2,11 +2,13 @@
 Handling vertically partitioned data
 """
 from copy import deepcopy
-from typing import List, Tuple, TypeVar
+from typing import List
+from typing import Tuple
+from typing import TypeVar
 from uuid import uuid4
 
-import numpy as np
 from PIL import Image
+import numpy as np
 
 # Ignore errors when running mypy script
 # mypy: ignore-errors

--- a/src/utils/synthea/__init__.py
+++ b/src/utils/synthea/__init__.py
@@ -1,1 +1,2 @@
-from .disease_labels import get_binary_labels_for_disease, get_diagnosis_date
+from .disease_labels import get_binary_labels_for_disease
+from .disease_labels import get_diagnosis_date

--- a/src/utils/synthea/disease_labels.py
+++ b/src/utils/synthea/disease_labels.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING
 
 import pandas as pd
 
-
 if TYPE_CHECKING:
     import numpy
 

--- a/tests/future/test_dataset.py
+++ b/tests/future/test_dataset.py
@@ -2,7 +2,8 @@ import pytest
 import syft as sy
 import torch as th
 
-from src.future import PartitionedDataset, VerticalDataset
+from src.future import PartitionedDataset
+from src.future import VerticalDataset
 
 hook = sy.TorchHook(th)
 

--- a/tests/future/test_dataset.py
+++ b/tests/future/test_dataset.py
@@ -1,9 +1,8 @@
 import pytest
-import torch as th
 import syft as sy
+import torch as th
 
 from src.future import PartitionedDataset, VerticalDataset
-
 
 hook = sy.TorchHook(th)
 

--- a/tests/test_dataloader.py
+++ b/tests/test_dataloader.py
@@ -2,6 +2,7 @@
 Test code in src/dataloader.py
 """
 import sys
+
 sys.path.append('../')
 from shutil import rmtree
 
@@ -10,9 +11,9 @@ import torch
 import torchvision.transforms as transforms
 from torchvision.datasets import MNIST
 
-from src.dataloader import VerticalDataLoader, SinglePartitionDataLoader
-from src.utils import add_ids, partition_dataset
+from src.dataloader import SinglePartitionDataLoader, VerticalDataLoader
 from src.psi.util import Client, Server
+from src.utils import add_ids, partition_dataset
 
 
 class TestSinglePartitionDataset:

--- a/tests/test_dataloader.py
+++ b/tests/test_dataloader.py
@@ -8,12 +8,15 @@ from shutil import rmtree
 
 import pytest
 import torch
-import torchvision.transforms as transforms
 from torchvision.datasets import MNIST
+import torchvision.transforms as transforms
 
-from src.dataloader import SinglePartitionDataLoader, VerticalDataLoader
-from src.psi.util import Client, Server
-from src.utils import add_ids, partition_dataset
+from src.dataloader import SinglePartitionDataLoader
+from src.dataloader import VerticalDataLoader
+from src.psi.util import Client
+from src.psi.util import Server
+from src.utils import add_ids
+from src.utils import partition_dataset
 
 
 class TestSinglePartitionDataset:

--- a/tests/test_psi.py
+++ b/tests/test_psi.py
@@ -5,7 +5,8 @@ import sys
 
 import pytest
 
-from src.psi.util import Client, Server
+from src.psi.util import Client
+from src.psi.util import Server
 
 
 @pytest.mark.parametrize(

--- a/tests/test_split_data.py
+++ b/tests/test_split_data.py
@@ -1,9 +1,9 @@
 """
 Test code in src/dataset.py
 """
+import uuid
 from copy import deepcopy
 from shutil import rmtree
-import uuid
 
 import numpy as np
 import pytest

--- a/tests/test_split_data.py
+++ b/tests/test_split_data.py
@@ -1,17 +1,18 @@
 """
 Test code in src/dataset.py
 """
-import uuid
 from copy import deepcopy
 from shutil import rmtree
+import uuid
 
 import numpy as np
 import pytest
 import torch
-import torchvision.transforms as transforms
 from torchvision.datasets import MNIST
+import torchvision.transforms as transforms
 
-from src.utils import add_ids, partition_dataset
+from src.utils import add_ids
+from src.utils import partition_dataset
 
 
 class TestPartition:


### PR DESCRIPTION
## Description
- Adds an isort profile to repo
- Tests imports are formatted correctly in CI
- Corrects import formatting

Fixes #76 

## Affected Dependencies
None

## How has this been tested?
- Ran `isort src -c -v` to check isort works

PR is good to go if an isort check is run as part of CI and it passes

## Checklist
- [X] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [X] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [X] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [X] My changes are covered by tests
